### PR TITLE
updating trie to handle sfx special cases.

### DIFF
--- a/common.go
+++ b/common.go
@@ -22,9 +22,18 @@ func PathSegmenter(path string, start int) (segment string, next int) {
 	if len(path) == 0 || start < 0 || start > len(path)-1 {
 		return "", -1
 	}
-	end := strings.IndexRune(path[start+1:], '/') // next '/' after 0th rune
+	end := strings.IndexRune(path[start+1:], segmenter) // next '/' after 0th rune
 	if end == -1 {
 		return path[start:], -1
 	}
 	return path[start : start+end+1], start + end + 1
+}
+
+var (
+	segmenter = '/'
+)
+
+// SetSegmenter will be used to change default segmenter
+func SetSegmenter(r rune) {
+	segmenter = r
 }

--- a/path_trie.go
+++ b/path_trie.go
@@ -26,14 +26,24 @@ func NewPathTrie() *PathTrie {
 // nodes or for nodes with a value of nil.
 func (trie *PathTrie) Get(key string) interface{} {
 	node := trie
+	var prevPart string
+	var prevNode *PathTrie
 	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
 		node = node.children[part]
 		if node == nil {
+			// sfx additional condition to return prev value
+			if len(part) > 0 && len(prevPart) > 0 {
+				if prevPart[0] == part[0] {
+					return prevNode.children[string(part[0])].value
+				}
+			}
 			return nil
 		}
 		if i == -1 {
 			break
 		}
+		prevNode = node
+		prevPart = part
 	}
 	return node.value
 }

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -19,11 +19,17 @@ func NewRuneTrie() *RuneTrie {
 // nodes or for nodes with a value of nil.
 func (trie *RuneTrie) Get(key string) interface{} {
 	node := trie
-	for _, r := range key {
+	prevNode := node
+	for idx, r := range key {
 		node = node.children[r]
 		if node == nil {
+			// sfx additional condition to return prev value
+			if idx > 0 && key[idx-1] == '.' {
+				return prevNode.value
+			}
 			return nil
 		}
+		prevNode = node
 	}
 	return node.value
 }

--- a/segmenter_test.go
+++ b/segmenter_test.go
@@ -72,3 +72,13 @@ func TestPathSegmenterEdgeCases(t *testing.T) {
 		}
 	}
 }
+
+func TestSetSegmenter(t *testing.T) {
+	if segmenter != '/' {
+		t.Error("default segmenter should be '/'")
+	}
+	SetSegmenter('.')
+	if segmenter != '.' {
+		t.Error("after calling set segmenter new segmenter should be '.'")
+	}
+}


### PR DESCRIPTION
summary: there is list of apm metric names which needs to be excluded.
    E.g. of such list is: ["spans.duration.", "tracing.duration.",
                           "gateway.tracing.", "dropped_spans"].
    Case 1:
    For all metric name in the list which ends with "." are termed as prefixes will be inserted in trie.
    If the last char of the list is "." then the value by the caller (in this case sbingest) should set
    it to "*" when making a Put() call. When doing a Get() if the node is nil; meaning that parent
    has Node has reached to its bottom most child; then check prevNode and see if its "."
    then return prevNode.value instead of nil. This will handle prefix matching for sfx use case.

   Case 2:
    For all metric name in the list which ends without "." are treated as full match. For such instances 
    we would get a non nil child at the end of the search and hence will return the value present at the 
    node.

test: verified modified trie with the above input and existing trie test cases.